### PR TITLE
Bump compileSdk, update dependencies, fix #18, #19 and #20

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           echo $KEYSTORE_FILE | base64 -d > my-release-key.keystore
 
       - name: Build release APK with Gradle
-        run: ./gradlew assembleRelease
+        run: ./gradlew build
         env:
           SIGNING_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: app/release/*
+          path: app/build/outputs/apk/release
           retention-days: 3
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
         run: |
-          echo $KEYSTORE_FILE | base64 -d > my-release-key.keystore
+          echo $KEYSTORE_FILE | base64 -d > app/my-release-key.keystore
 
       - name: Build release APK with Gradle
         run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: 'Publish new release with Andorid APK'
+
+on:
+  push:
+    tags: ['v*']
+# This workflow will trigger on each push of a tag that starts with a "v" to create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Decode Keystore from GitHub Secrets
+        env:
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+        run: |
+          echo $KEYSTORE_FILE | base64 -d > my-release-key.keystore
+
+      - name: Build release APK with Gradle
+        run: ./gradlew assembleRelease
+        env:
+          SIGNING_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+
+      - name: Post Build | Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: app/release/*
+          retention-days: 3
+          if-no-files-found: error
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Download binary from previous job
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Display structure of downloaded files
+        run: ls artifacts
+
+      # Upload release asset:  https://github.com/actions/upload-release-asset
+      # which recommends:      https://github.com/softprops/action-gh-release
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
+        with:
+          files: artifacts/*

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,9 @@ captures/
 
 # Keystore files
 *.jks
+
+# Grade Built files:
+app/build/
+
+# Intellij APK Release:
+app/release/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,14 +15,23 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
-    buildTypes {
+    signingConfigs {
+        release {
+            storeFile file(System.getenv("SIGNING_STORE_FILE") ?: "my-release-key.keystore")
+            storePassword System.getenv("SIGNING_STORE_PASSWORD")
+            keyAlias System.getenv("SIGNING_KEY_ALIAS")
+            keyPassword System.getenv("SIGNING_KEY_PASSWORD")
+        }
+    }
 
+    buildTypes {
         debug {
             minifyEnabled false
             applicationIdSuffix '.debug'
         }
 
         release {
+            signingConfig signingConfigs.release
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,10 @@ android {
     signingConfigs {
         def keystoreFilePath = System.getenv("SIGNING_STORE_FILE") ?: "my-release-key.keystore"
 
-        if (file(keystoreFilePath).exists()) {
+        if (file(keystoreFilePath).exists() ||
+                System.getenv("SIGNING_STORE_PASSWORD") ||
+                System.getenv("SIGNING_KEY_ALIAS") ||
+                System.getenv("SIGNING_KEY_PASSWORD")) {
             release {
                 storeFile file(keystoreFilePath)
                 storePassword System.getenv("SIGNING_STORE_PASSWORD")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,11 +16,15 @@ android {
     }
 
     signingConfigs {
-        release {
-            storeFile file(System.getenv("SIGNING_STORE_FILE") ?: "my-release-key.keystore")
-            storePassword System.getenv("SIGNING_STORE_PASSWORD")
-            keyAlias System.getenv("SIGNING_KEY_ALIAS")
-            keyPassword System.getenv("SIGNING_KEY_PASSWORD")
+        def keystoreFilePath = System.getenv("SIGNING_STORE_FILE") ?: "my-release-key.keystore"
+
+        if (file(keystoreFilePath).exists()) {
+            release {
+                storeFile file(keystoreFilePath)
+                storePassword System.getenv("SIGNING_STORE_PASSWORD")
+                keyAlias System.getenv("SIGNING_KEY_ALIAS")
+                keyPassword System.getenv("SIGNING_KEY_PASSWORD")
+            }
         }
     }
 
@@ -31,7 +35,10 @@ android {
         }
 
         release {
-            signingConfig signingConfigs.release
+            // Apply signingConfig only if it was configured
+            if (signingConfigs.hasProperty('release')) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,7 @@ android {
 
         debug {
             minifyEnabled false
+            applicationIdSuffix '.debug'
         }
 
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 33
     buildToolsVersion "30.0.3"
+    namespace 'de.dotwee.micropinner'
 
     defaultConfig {
         applicationId "de.dotwee.micropinner"
-        namespace 'de.dotwee.micropinner'
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 29

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ android {
 
     defaultConfig {
         applicationId "de.dotwee.micropinner"
+        namespace 'de.dotwee.micropinner'
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 29

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "de.dotwee.micropinner"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 33
         versionCode 29
         versionName "v2.2.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -34,20 +34,20 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
 
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1') {
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.5.0') {
         // Necessary if your app targets Marshmallow (since Espresso
         // hasn't moved to Marshmallow yet)
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
-    androidTestImplementation('com.android.support.test.espresso:espresso-intents:3.0.1') {
+    androidTestImplementation('androidx.test.espresso:espresso-intents:3.5.0') {
         // Necessary to avoid version conflicts
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
-    androidTestImplementation('com.android.support.test:runner:1.0.1') {
+    androidTestImplementation('androidx.test.ext:junit:1.1.4') {
         // Necessary if your app targets Marshmallow (since the test runner
         // hasn't moved to Marshmallow yet)
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/app/src/androidTest/java/de/dotwee/micropinner/tools/Matches.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/tools/Matches.java
@@ -3,6 +3,7 @@ package de.dotwee.micropinner.tools;
 import android.graphics.drawable.ColorDrawable;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
+import androidx.test.espresso.Root;
 import androidx.test.espresso.intent.Checks;
 import androidx.test.espresso.matcher.BoundedMatcher;
 import android.view.View;
@@ -15,6 +16,15 @@ import org.hamcrest.Matcher;
  * Created by Lukas Wolfsteiner on 06.11.2015.
  */
 public final class Matches {
+
+    @NonNull
+    public static Matcher<Root> isToast() {
+        return new ToastMatcher();
+    }
+    @NonNull
+    public static Matcher<Root> isToast(int maxRetries) {
+        return new ToastMatcher(maxRetries);
+    }
 
     /**
      * This matcher checks if a TextView displays its text in

--- a/app/src/androidTest/java/de/dotwee/micropinner/tools/Matches.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/tools/Matches.java
@@ -1,10 +1,10 @@
 package de.dotwee.micropinner.tools;
 
 import android.graphics.drawable.ColorDrawable;
-import android.support.annotation.ColorInt;
-import android.support.annotation.NonNull;
-import android.support.test.espresso.intent.Checks;
-import android.support.test.espresso.matcher.BoundedMatcher;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.test.espresso.intent.Checks;
+import androidx.test.espresso.matcher.BoundedMatcher;
 import android.view.View;
 import android.widget.TextView;
 

--- a/app/src/androidTest/java/de/dotwee/micropinner/tools/PreferencesHandlerTest.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/tools/PreferencesHandlerTest.java
@@ -2,8 +2,8 @@ package de.dotwee.micropinner.tools;
 
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/app/src/androidTest/java/de/dotwee/micropinner/tools/TestTools.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/tools/TestTools.java
@@ -1,6 +1,6 @@
 package de.dotwee.micropinner.tools;
 
-import android.support.test.rule.ActivityTestRule;
+import androidx.test.rule.ActivityTestRule;
 
 import de.dotwee.micropinner.view.MainDialog;
 

--- a/app/src/androidTest/java/de/dotwee/micropinner/tools/ToastMatcher.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/tools/ToastMatcher.java
@@ -1,0 +1,68 @@
+package de.dotwee.micropinner.tools;
+
+import android.os.IBinder;
+import androidx.test.espresso.Root;
+import android.view.WindowManager.LayoutParams;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * This class allows to match Toast messages in tests with Espresso.
+ *
+ * Idea taken from: <a href="https://stackoverflow.com/questions/28390574/checking-toast-message-in-android-espresso">Checking toast message in android espresso - Stack Overflow</a>
+ *
+ * Usage in test class:
+ *
+ * <pre>
+ * {@code
+ * import somepkg.ToastMatcher.Companion.onToast;
+ *
+ * // To assert a toast does *not* pop up:
+ * onView(withText("text")).inRoot(new ToastMatcher()).check(doesNotExist());
+ * onView(withText(textId)).inRoot(new ToastMatcher()).check(doesNotExist());
+ *
+ * // To assert a toast does pop up:
+ * onView(withText("text")).inRoot(new ToastMatcher()).check(matches(isDisplayed()));
+ * onView(withText(textId)).inRoot(new ToastMatcher()).check(matches(isDisplayed()));
+ * }
+ */
+public class ToastMatcher extends TypeSafeMatcher<Root> {
+
+    /** Default for maximum number of retries to wait for the toast to pop up */
+    private static final int DEFAULT_MAX_FAILURES = 5;
+
+    /** Restrict number of false results from matchesSafely to avoid endless loop */
+    private int failures = 0;
+    private final int maxFailures;
+
+    public ToastMatcher() {
+        this(DEFAULT_MAX_FAILURES);
+    }
+    public ToastMatcher(int maxFailures) {
+        this.maxFailures = maxFailures;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is toast");
+    }
+
+    @Override
+    public boolean matchesSafely(Root root) {
+        int type = root.getWindowLayoutParams().get().type;
+        if (type == LayoutParams.TYPE_TOAST || type == LayoutParams.TYPE_APPLICATION_OVERLAY) {
+            IBinder windowToken = root.getDecorView().getWindowToken();
+            IBinder appToken = root.getDecorView().getApplicationWindowToken();
+            if (windowToken == appToken) {
+                // windowToken == appToken means this window isn't contained by any other windows.
+                // if it was a window for an activity, it would have TYPE_BASE_APPLICATION.
+                return true;
+            }
+        }
+        // Method is called again if false is returned which is useful because a toast may take some time to pop up. But for
+        // obvious reasons an infinite wait isn't of help. So false is only returned as often as maxFailures specifies.
+        return (++failures >= maxFailures);
+    }
+
+}

--- a/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogNewPinTest.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogNewPinTest.java
@@ -9,14 +9,15 @@ import org.junit.runner.RunWith;
 
 import de.dotwee.micropinner.R;
 import de.dotwee.micropinner.database.PinDatabase;
+import de.dotwee.micropinner.tools.Matches;
 import de.dotwee.micropinner.tools.PreferencesHandler;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isFocusable;
@@ -108,9 +109,12 @@ public class MainDialogNewPinTest {
         // click pin button
         onView(withText(R.string.dialog_action_pin)).perform(click());
 
+        // can't see toast if another toast is already present
+        onView(withText(R.string.message_visibility_unsupported)).inRoot(Matches.isToast())
+                .check(doesNotExist());
+
         // verify toast existence
-        onView(withText(R.string.message_empty_title)).inRoot(
-                withDecorView(not(activityTestRule.getActivity().getWindow().getDecorView())))
+        onView(withText(R.string.message_empty_title)).inRoot(Matches.isToast())
                 .check(matches(isDisplayed()));
     }
 

--- a/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogNewPinTest.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogNewPinTest.java
@@ -1,7 +1,7 @@
 package de.dotwee.micropinner.view;
 
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,18 +11,18 @@ import de.dotwee.micropinner.R;
 import de.dotwee.micropinner.database.PinDatabase;
 import de.dotwee.micropinner.tools.PreferencesHandler;
 
-import static android.support.test.espresso.Espresso.onData;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.typeText;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
-import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.isFocusable;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withSpinnerText;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isFocusable;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withSpinnerText;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static de.dotwee.micropinner.tools.TestTools.getPreferencesHandler;
 import static de.dotwee.micropinner.tools.TestTools.recreateActivity;
 import static org.hamcrest.Matchers.allOf;

--- a/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogParentPinTest.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogParentPinTest.java
@@ -3,10 +3,11 @@ package de.dotwee.micropinner.view;
 import android.annotation.TargetApi;
 import android.content.Intent;
 import android.os.Build;
-import android.support.test.espresso.intent.Intents;
-import android.support.test.espresso.matcher.ViewMatchers;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.espresso.intent.Intents;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
 
 import org.junit.After;
 import org.junit.Before;
@@ -18,12 +19,12 @@ import de.dotwee.micropinner.Constants;
 import de.dotwee.micropinner.R;
 import de.dotwee.micropinner.tools.NotificationTools;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withSpinnerText;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withSpinnerText;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 /**
  * Created by Lukas Wolfsteiner on 06.11.2015.

--- a/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogParentPinTest.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogParentPinTest.java
@@ -4,13 +4,13 @@ import android.annotation.TargetApi;
 import android.content.Intent;
 import android.os.Build;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.ActivityTestRule;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,19 +39,11 @@ public class MainDialogParentPinTest {
      * activity to be launched before each test
      */
     @Rule
-    public ActivityTestRule<MainDialog> activityTestRule =
-            new ActivityTestRule<>(MainDialog.class);
-
-    @Before
-    public void setUp() {
-
-        final Intent testIntent =
-                new Intent(activityTestRule.getActivity(), MainDialog.class).putExtra(
-                        NotificationTools.EXTRA_INTENT, Constants.testPin);
-
-        Intents.init();
-        activityTestRule.launchActivity(testIntent);
-    }
+    public ActivityScenarioRule<MainDialog> activityTestRule =
+            new ActivityScenarioRule<>(
+                    new Intent(ApplicationProvider.getApplicationContext(), MainDialog.class)
+                            .putExtra(NotificationTools.EXTRA_INTENT, Constants.testPin)
+            );
 
     /**
      * @throws Exception

--- a/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogThemeTest.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogThemeTest.java
@@ -5,6 +5,7 @@ import android.os.Build;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
+import androidx.test.filters.SdkSuppress;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.core.content.ContextCompat;
@@ -40,6 +41,7 @@ public class MainDialogThemeTest {
             new ActivityTestRule<>(MainDialog.class);
 
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
     @ColorInt
     private static int getAccentColor(@NonNull ActivityTestRule<MainDialog> activityTestRule, boolean light) {
         Configuration configuration = new Configuration();
@@ -49,6 +51,7 @@ public class MainDialogThemeTest {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
     @ColorInt
     private static int getBackgroundColor(@NonNull ActivityTestRule<MainDialog> activityTestRule, boolean light) {
         Configuration configuration = new Configuration();
@@ -73,6 +76,7 @@ public class MainDialogThemeTest {
      * This method verifies the light theme's accent.
      */
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
     @Test
     public void testThemeLightAccent() throws Exception {
         changeUiMode(activityTestRule, AppCompatDelegate.MODE_NIGHT_NO);
@@ -90,6 +94,7 @@ public class MainDialogThemeTest {
      * This method verifies the light theme's background.
      */
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
     @Test
     public void testThemeLightBackground() throws Exception {
         changeUiMode(activityTestRule, AppCompatDelegate.MODE_NIGHT_NO);
@@ -101,6 +106,7 @@ public class MainDialogThemeTest {
      * This method verifies the light theme's accent.
      */
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
     @Test
     public void testThemeDarkAccent() throws Exception {
         changeUiMode(activityTestRule, AppCompatDelegate.MODE_NIGHT_YES);
@@ -120,6 +126,7 @@ public class MainDialogThemeTest {
      * This method verifies the dark theme's background.
      */
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN_MR1)
     @Test
     public void testThemeDarkBackground() throws Exception {
         changeUiMode(activityTestRule, AppCompatDelegate.MODE_NIGHT_YES);

--- a/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogThemeTest.java
+++ b/app/src/androidTest/java/de/dotwee/micropinner/view/MainDialogThemeTest.java
@@ -2,13 +2,13 @@ package de.dotwee.micropinner.view;
 
 import android.content.res.Configuration;
 import android.os.Build;
-import android.support.annotation.ColorInt;
-import android.support.annotation.NonNull;
-import android.support.annotation.RequiresApi;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatDelegate;
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.core.content.ContextCompat;
+import androidx.appcompat.app.AppCompatDelegate;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -18,10 +18,10 @@ import org.junit.runner.RunWith;
 import de.dotwee.micropinner.R;
 import de.dotwee.micropinner.tools.Matches;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static de.dotwee.micropinner.tools.TestTools.recreateActivity;
 
 /**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:excludeFromRecents="true"
             android:label="@string/main_name"
             android:theme="@style/DialogTheme"
+            android:launchMode="singleInstance"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="de.dotwee.micropinner">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
             android:name=".view.MainDialog"
             android:excludeFromRecents="true"
             android:label="@string/main_name"
-            android:theme="@style/DialogTheme">
+            android:theme="@style/DialogTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="de.dotwee.micropinner">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:excludeFromRecents="true"
             android:label="@string/main_name"
             android:theme="@style/DialogTheme"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,10 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <queries>
         <intent>
+
             <!-- Allow custom text actions (like "search selected text") -->
             <action android:name="android.intent.action.PROCESS_TEXT" />
             <data android:mimeType="text/plain" />
@@ -23,11 +24,11 @@
         <activity
             android:name=".view.MainDialog"
             android:excludeFromRecents="true"
-            android:theme="@style/DialogTheme"
+            android:exported="true"
             android:launchMode="singleInstance"
             android:noHistory="true"
-            android:windowSoftInputMode="adjustResize"
-            android:exported="true">
+            android:theme="@style/DialogTheme"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -36,14 +37,20 @@
         </activity>
 
         <receiver android:name=".receiver.OnDeleteReceiver" />
-
         <receiver android:name=".receiver.OnClipReceiver" />
-
         <receiver
             android:name=".receiver.OnBootReceiver"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        <receiver
+            android:name=".receiver.OnUpdateReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
         <activity
             android:name=".view.MainDialog"
             android:excludeFromRecents="true"
-            android:label="@string/main_name"
             android:theme="@style/DialogTheme"
             android:launchMode="singleInstance"
             android:noHistory="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
             android:label="@string/main_name"
             android:theme="@style/DialogTheme"
             android:launchMode="singleInstance"
+            android:noHistory="true"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,14 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
+    <queries>
+        <intent>
+            <!-- Allow custom text actions (like "search selected text") -->
+            <action android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:fullBackupContent="true"

--- a/app/src/main/java/de/dotwee/micropinner/database/PinDatabase.java
+++ b/app/src/main/java/de/dotwee/micropinner/database/PinDatabase.java
@@ -5,8 +5,8 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.support.annotation.NonNull;
-import android.support.v4.util.ArrayMap;
+import androidx.annotation.NonNull;
+import androidx.collection.ArrayMap;
 import android.util.Log;
 
 import java.util.Map;

--- a/app/src/main/java/de/dotwee/micropinner/database/PinSpec.java
+++ b/app/src/main/java/de/dotwee/micropinner/database/PinSpec.java
@@ -3,7 +3,7 @@ package de.dotwee.micropinner.database;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.Serializable;
 

--- a/app/src/main/java/de/dotwee/micropinner/database/PinSpec.java
+++ b/app/src/main/java/de/dotwee/micropinner/database/PinSpec.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.DatabaseUtils;
 import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat.NotificationVisibility;
 
 import java.io.Serializable;
 
@@ -90,6 +91,7 @@ public class PinSpec implements Serializable {
         this.content = content;
     }
 
+    @NotificationVisibility
     public int getVisibility() {
         return visibility;
     }
@@ -145,6 +147,7 @@ public class PinSpec implements Serializable {
         }
     }
 
+    @NonNull
     @Override
     public String toString() {
         return "PinSpec{" +

--- a/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenter.java
+++ b/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenter.java
@@ -17,6 +17,15 @@ public interface MainPresenter {
     void onSwitchHold();
 
     /**
+     * This method handles the result of a permission request that was made on the presenters behalf by an activity.
+     * @param permissions The requested permissions.
+     * @param grantResults The grant results for the corresponding permissions which is either PERMISSION_GRANTED or PERMISSION_DENIED.
+     * @see <a href="https://developer.android.com/reference/androidx/core/app/ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int,java.lang.String[],int[])">ActivityCompat.OnRequestPermissionsResultCallback | Android Developers</a>
+     */
+    void onRequestPermissionsResult(@NonNull String[] permissions,
+                                    @NonNull int[] grantResults);
+
+    /**
      * This method handles the click on the positive dialog button.
      */
     void onButtonPositive();

--- a/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenter.java
+++ b/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenter.java
@@ -1,7 +1,7 @@
 package de.dotwee.micropinner.presenter;
 
 import android.app.Activity;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import de.dotwee.micropinner.database.PinSpec;
 

--- a/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenterImpl.java
+++ b/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenterImpl.java
@@ -10,14 +10,15 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
+import androidx.appcompat.widget.SwitchCompat;
 import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationCompat;
 
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -166,7 +167,7 @@ public class MainPresenterImpl implements MainPresenter {
         // restore the switch's state if advanced is enabled
         if (preferencesHandler.isAdvancedUsed()) {
 
-            Switch advancedSwitch = activity.findViewById(R.id.switchAdvanced);
+            SwitchCompat advancedSwitch = activity.findViewById(R.id.switchAdvanced);
             if (advancedSwitch != null) {
 
                 advancedSwitch.setChecked(true);
@@ -223,7 +224,7 @@ public class MainPresenterImpl implements MainPresenter {
         if (intent != null) {
             Serializable extra = intent.getSerializableExtra(NotificationTools.EXTRA_INTENT);
 
-            if (extra != null && extra instanceof PinSpec) {
+            if (extra instanceof PinSpec) {
                 this.parentPin = (PinSpec) extra;
                 return true;
             }
@@ -308,20 +309,17 @@ public class MainPresenterImpl implements MainPresenter {
             int visibilityPosition;
 
             switch (parentPin.getVisibility()) {
-                case Notification.VISIBILITY_PUBLIC:
+                case NotificationCompat.VISIBILITY_PUBLIC:
+                default:
                     visibilityPosition = 0;
                     break;
 
-                case Notification.VISIBILITY_PRIVATE:
+                case NotificationCompat.VISIBILITY_PRIVATE:
                     visibilityPosition = 1;
                     break;
 
-                case Notification.VISIBILITY_SECRET:
+                case NotificationCompat.VISIBILITY_SECRET:
                     visibilityPosition = 2;
-                    break;
-
-                default:
-                    visibilityPosition = 0;
                     break;
             }
 
@@ -337,6 +335,7 @@ public class MainPresenterImpl implements MainPresenter {
             int priorityPosition;
 
             switch (parentPin.getPriority()) {
+                default:
                 case Notification.PRIORITY_DEFAULT:
                     priorityPosition = 0;
                     break;
@@ -351,10 +350,6 @@ public class MainPresenterImpl implements MainPresenter {
 
                 case Notification.PRIORITY_HIGH:
                     priorityPosition = 3;
-                    break;
-
-                default:
-                    priorityPosition = 0;
                     break;
             }
 

--- a/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenterImpl.java
+++ b/app/src/main/java/de/dotwee/micropinner/presenter/MainPresenterImpl.java
@@ -6,7 +6,7 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;

--- a/app/src/main/java/de/dotwee/micropinner/receiver/OnBootReceiver.java
+++ b/app/src/main/java/de/dotwee/micropinner/receiver/OnBootReceiver.java
@@ -3,8 +3,8 @@ package de.dotwee.micropinner.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.util.Map;

--- a/app/src/main/java/de/dotwee/micropinner/receiver/OnClipReceiver.java
+++ b/app/src/main/java/de/dotwee/micropinner/receiver/OnClipReceiver.java
@@ -5,7 +5,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 import android.widget.Toast;
 

--- a/app/src/main/java/de/dotwee/micropinner/receiver/OnDeleteReceiver.java
+++ b/app/src/main/java/de/dotwee/micropinner/receiver/OnDeleteReceiver.java
@@ -3,7 +3,7 @@ package de.dotwee.micropinner.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import de.dotwee.micropinner.database.PinDatabase;

--- a/app/src/main/java/de/dotwee/micropinner/receiver/OnUpdateReceiver.java
+++ b/app/src/main/java/de/dotwee/micropinner/receiver/OnUpdateReceiver.java
@@ -10,7 +10,7 @@ import androidx.annotation.Nullable;
 
 import de.dotwee.micropinner.tools.NotificationTools;
 
-public class OnBootReceiver extends BroadcastReceiver {
+public class OnUpdateReceiver extends BroadcastReceiver {
     private final static String TAG = OnBootReceiver.class.getSimpleName();
 
     @Override
@@ -21,9 +21,9 @@ public class OnBootReceiver extends BroadcastReceiver {
             return;
         }
 
-        if (!intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
-            Log.w(TAG, "OnBootReceiver's intent actions is not "
-                    + Intent.ACTION_BOOT_COMPLETED
+        if (!intent.getAction().equals(Intent.ACTION_MY_PACKAGE_REPLACED)) {
+            Log.w(TAG, "OnUpdateReceiver's intent actions is not "
+                    + Intent.ACTION_MY_PACKAGE_REPLACED
                     + ", returning without work");
             return;
         }

--- a/app/src/main/java/de/dotwee/micropinner/receiver/OnUpdateReceiver.java
+++ b/app/src/main/java/de/dotwee/micropinner/receiver/OnUpdateReceiver.java
@@ -10,6 +10,11 @@ import androidx.annotation.Nullable;
 
 import de.dotwee.micropinner.tools.NotificationTools;
 
+/**
+ * This receiver is used when the app is updated to ensure notifications are restored immediately.
+ *
+ * @see <a href="https://stackoverflow.com/questions/26475721/push-notification-after-app-was-updated">android - Push Notification After App Was Updated - Stack Overflow</a>
+ */
 public class OnUpdateReceiver extends BroadcastReceiver {
     private final static String TAG = OnBootReceiver.class.getSimpleName();
 

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -36,6 +36,10 @@ public class NotificationTools {
      */
     public final static String EXTRA_INTENT = "IAMAPIN";
 
+    /**
+     * Used in app version 2.2.0 and earlier.
+     */
+    private static final String CHANNEL_NAME_OLD = "pin_channel";
     private static final String CHANNEL_NAME_PUBLIC = "pin_channel_public";
     private static final String CHANNEL_NAME_PRIVATE = "pin_channel_private";
     private static final String CHANNEL_NAME_SECRET = "pin_channel_secret";
@@ -117,6 +121,10 @@ public class NotificationTools {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private static void createOrUpdateNotificationChannels(@NonNull Context context, @NonNull NotificationManager notificationManager) {
+        // Delete old channel used in version 2.2.0 and earlier:
+        notificationManager.deleteNotificationChannel(CHANNEL_NAME_OLD);
+
+        // Create one channel per visibility level to allow user to customize how they are shown on the lock screen:
         NotificationChannel public_channel = new NotificationChannel(CHANNEL_NAME_PUBLIC,
                 context.getResources().getString(R.string.notifications_channel_public),
                 NotificationManager.IMPORTANCE_DEFAULT);
@@ -164,6 +172,7 @@ public class NotificationTools {
                         .setContentText(pin.getContent())
                         .setSmallIcon(R.drawable.ic_notif_star)
                         .setOnlyAlertOnce(true)
+                        .setCategory(NotificationCompat.CATEGORY_REMINDER)
                         .setPriority(pin.getPriority())
                         .setVisibility(pin.getVisibility())
                         .setStyle(new NotificationCompat.BigTextStyle().bigText(pin.getContent()))

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -122,6 +122,7 @@ public class NotificationTools {
     @RequiresApi(api = Build.VERSION_CODES.O)
     private static void createOrUpdateNotificationChannels(@NonNull Context context, @NonNull NotificationManager notificationManager) {
         // Use low importance in order to not make a sound when creating a notification.
+        // If this is too low then the user should be able to manually change channel settings, so this seems like a sensible default.
         // See: https://developer.android.com/develop/ui/views/notifications/channels#importance
         final int importance = NotificationManager.IMPORTANCE_LOW;
 
@@ -132,16 +133,28 @@ public class NotificationTools {
         NotificationChannel public_channel = new NotificationChannel(CHANNEL_NAME_PUBLIC,
                 context.getResources().getString(R.string.notifications_channel_public),
                 importance);
+        public_channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);
+        public_channel.setShowBadge(false);
+        public_channel.enableLights(false);
+        public_channel.enableVibration(false);
         notificationManager.createNotificationChannel(public_channel);
 
         NotificationChannel private_channel = new NotificationChannel(CHANNEL_NAME_PRIVATE,
                 context.getResources().getString(R.string.notifications_channel_private),
                 importance);
+        private_channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+        private_channel.setShowBadge(false);
+        private_channel.enableLights(false);
+        private_channel.enableVibration(false);
         notificationManager.createNotificationChannel(private_channel);
 
         NotificationChannel secret_channel = new NotificationChannel(CHANNEL_NAME_SECRET,
                 context.getResources().getString(R.string.notifications_channel_secret),
                 importance);
+        secret_channel.setLockscreenVisibility(Notification.VISIBILITY_SECRET);
+        secret_channel.setShowBadge(false);
+        secret_channel.enableLights(false);
+        secret_channel.enableVibration(false);
         notificationManager.createNotificationChannel(secret_channel);
     }
 

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -163,6 +163,7 @@ public class NotificationTools {
                         .setContentTitle(pin.getTitle())
                         .setContentText(pin.getContent())
                         .setSmallIcon(R.drawable.ic_notif_star)
+                        .setOnlyAlertOnce(true)
                         .setPriority(pin.getPriority())
                         .setVisibility(pin.getVisibility())
                         .setStyle(new NotificationCompat.BigTextStyle().bigText(pin.getContent()))

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -223,6 +223,7 @@ public class NotificationTools {
                         .setContentText(pin.getContent())
                         .setSmallIcon(R.drawable.ic_notif_star)
                         .setOnlyAlertOnce(true)
+                        .setSilent(true)
                         .setCategory(NotificationCompat.CATEGORY_REMINDER)
                         .setPriority(pin.getPriority())
                         .setVisibility(pin.getVisibility())

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -8,8 +8,8 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationCompat;
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
 import android.util.Log;
 
 import de.dotwee.micropinner.R;
@@ -27,13 +27,18 @@ public class NotificationTools {
     private static final String CHANNEL_NAME = "pin_channel";
     private static final String TAG = NotificationTools.class.getSimpleName();
 
+    /** Needed for later android versions, see:
+     * https://stackoverflow.com/questions/67045607/how-to-resolve-missing-pendingintent-mutability-flag-lint-warning-in-android-a
+     */
+    private static final int FLAG_IMMUTABLE = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0;
+
     @NonNull
     private static PendingIntent getPinIntent(@NonNull Context context, @NonNull PinSpec pin) {
         Intent resultIntent = new Intent(context, MainDialog.class);
         resultIntent.putExtra(EXTRA_INTENT, pin);
 
         return PendingIntent.getActivity(context, (int) pin.getId(), resultIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE);
     }
 
     @NonNull
@@ -81,7 +86,7 @@ public class NotificationTools {
 
                         .setDeleteIntent(PendingIntent.getBroadcast(context, (int) pin.getId(),
                                 new Intent(context, OnDeleteReceiver.class).setAction("notification_cancelled")
-                                        .putExtra(EXTRA_INTENT, pin), PendingIntent.FLAG_CANCEL_CURRENT))
+                                        .putExtra(EXTRA_INTENT, pin), PendingIntent.FLAG_CANCEL_CURRENT | FLAG_IMMUTABLE))
                         .setOngoing(pin.isPersistent());
 
         if (pin.isShowActions()) {
@@ -89,7 +94,7 @@ public class NotificationTools {
                     context.getString(R.string.message_save_to_clipboard),
                     PendingIntent.getBroadcast(context, (int) pin.getId(),
                             new Intent(context, OnClipReceiver.class).putExtra(EXTRA_INTENT, pin),
-                            PendingIntent.FLAG_CANCEL_CURRENT));
+                            PendingIntent.FLAG_CANCEL_CURRENT | FLAG_IMMUTABLE));
         }
 
         if (notificationManager != null) {

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -103,11 +103,11 @@ public class NotificationTools {
 
     private static String getChannelName(@NonNull PinSpec pin) {
         switch (pin.getVisibility()) {
-            case Notification.VISIBILITY_PUBLIC:
+            case NotificationCompat.VISIBILITY_PUBLIC:
                 return CHANNEL_NAME_PUBLIC;
-            case Notification.VISIBILITY_PRIVATE:
+            case NotificationCompat.VISIBILITY_PRIVATE:
                 return CHANNEL_NAME_PRIVATE;
-            case Notification.VISIBILITY_SECRET:
+            case NotificationCompat.VISIBILITY_SECRET:
                 return CHANNEL_NAME_SECRET;
             default:
                 throw new RuntimeException("Unknown visibility value");
@@ -141,7 +141,7 @@ public class NotificationTools {
                                         .putExtra(EXTRA_INTENT, pin), PendingIntent.FLAG_CANCEL_CURRENT | FLAG_IMMUTABLE))
                         .setOngoing(pin.isPersistent());
 
-        if (pin.getVisibility() == Notification.VISIBILITY_PRIVATE && !pin.getContent().isEmpty()) {
+        if (pin.getVisibility() == NotificationCompat.VISIBILITY_PRIVATE && !pin.getContent().isEmpty()) {
             // If visibility is hidden then an alternative notification can be shown on the lock screen:
             // More info: https://developer.android.com/develop/ui/views/notifications/build-notification#lockscreenNotification
             // More info: https://gabrieltanner.org/blog/android-notifications-overview/

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -223,7 +223,6 @@ public class NotificationTools {
                         .setContentText(pin.getContent())
                         .setSmallIcon(R.drawable.ic_notif_star)
                         .setOnlyAlertOnce(true)
-                        .setSilent(true)
                         .setCategory(NotificationCompat.CATEGORY_REMINDER)
                         .setPriority(pin.getPriority())
                         .setVisibility(pin.getVisibility())

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -121,23 +121,27 @@ public class NotificationTools {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private static void createOrUpdateNotificationChannels(@NonNull Context context, @NonNull NotificationManager notificationManager) {
+        // Use low importance in order to not make a sound when creating a notification.
+        // See: https://developer.android.com/develop/ui/views/notifications/channels#importance
+        final int importance = NotificationManager.IMPORTANCE_LOW;
+
         // Delete old channel used in version 2.2.0 and earlier:
         notificationManager.deleteNotificationChannel(CHANNEL_NAME_OLD);
 
         // Create one channel per visibility level to allow user to customize how they are shown on the lock screen:
         NotificationChannel public_channel = new NotificationChannel(CHANNEL_NAME_PUBLIC,
                 context.getResources().getString(R.string.notifications_channel_public),
-                NotificationManager.IMPORTANCE_DEFAULT);
+                importance);
         notificationManager.createNotificationChannel(public_channel);
 
         NotificationChannel private_channel = new NotificationChannel(CHANNEL_NAME_PRIVATE,
                 context.getResources().getString(R.string.notifications_channel_private),
-                NotificationManager.IMPORTANCE_DEFAULT);
+                importance);
         notificationManager.createNotificationChannel(private_channel);
 
         NotificationChannel secret_channel = new NotificationChannel(CHANNEL_NAME_SECRET,
                 context.getResources().getString(R.string.notifications_channel_secret),
-                NotificationManager.IMPORTANCE_DEFAULT);
+                importance);
         notificationManager.createNotificationChannel(secret_channel);
     }
 

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -7,9 +7,15 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Typeface;
 import android.os.Build;
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
+
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.StyleSpan;
 import android.util.Log;
 
 import de.dotwee.micropinner.R;
@@ -22,9 +28,15 @@ import de.dotwee.micropinner.view.MainDialog;
  * Created by lukas on 10.08.2016.
  */
 public class NotificationTools {
+    /**
+     * Name of extra data inside intents that contains a PinSpec object with data about the parent pin.
+     */
     public final static String EXTRA_INTENT = "IAMAPIN";
 
-    private static final String CHANNEL_NAME = "pin_channel";
+    private static final String CHANNEL_NAME_PUBLIC = "pin_channel_public";
+    private static final String CHANNEL_NAME_PRIVATE = "pin_channel_private";
+    private static final String CHANNEL_NAME_SECRET = "pin_channel_secret";
+
     private static final String TAG = NotificationTools.class.getSimpleName();
 
     /** Needed for later android versions, see:
@@ -68,15 +80,55 @@ public class NotificationTools {
                 break;
         }
 
-        return new NotificationChannel(NotificationChannel.DEFAULT_CHANNEL_ID, CHANNEL_NAME, importance);
+        return new NotificationChannel(NotificationChannel.DEFAULT_CHANNEL_ID, CHANNEL_NAME_PUBLIC, importance);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private static void createOrUpdateNotificationChannels(@NonNull Context context, @NonNull NotificationManager notificationManager) {
+        NotificationChannel public_channel = new NotificationChannel(CHANNEL_NAME_PUBLIC,
+                context.getResources().getString(R.string.notifications_channel_public),
+                NotificationManager.IMPORTANCE_DEFAULT);
+        notificationManager.createNotificationChannel(public_channel);
+
+        NotificationChannel private_channel = new NotificationChannel(CHANNEL_NAME_PRIVATE,
+                context.getResources().getString(R.string.notifications_channel_private),
+                NotificationManager.IMPORTANCE_DEFAULT);
+        notificationManager.createNotificationChannel(private_channel);
+
+        NotificationChannel secret_channel = new NotificationChannel(CHANNEL_NAME_SECRET,
+                context.getResources().getString(R.string.notifications_channel_secret),
+                NotificationManager.IMPORTANCE_DEFAULT);
+        notificationManager.createNotificationChannel(secret_channel);
+    }
+
+    private static String getChannelName(@NonNull PinSpec pin) {
+        switch (pin.getVisibility()) {
+            case Notification.VISIBILITY_PUBLIC:
+                return CHANNEL_NAME_PUBLIC;
+            case Notification.VISIBILITY_PRIVATE:
+                return CHANNEL_NAME_PRIVATE;
+            case Notification.VISIBILITY_SECRET:
+                return CHANNEL_NAME_SECRET;
+            default:
+                throw new RuntimeException("Unknown visibility value");
+        }
+    }
+
+    private static Spannable styledText(CharSequence text, StyleSpan style) {
+        // https://stackoverflow.com/questions/70698860/how-to-bold-title-in-notification
+        Spannable content = new SpannableString(text);
+        content.setSpan(style, 0, text.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        return content;
     }
 
     public static void notify(@NonNull Context context, @NonNull PinSpec pin) {
         NotificationManager notificationManager =
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
+        String channel_id = getChannelName(pin);
         NotificationCompat.Builder builder =
-                new NotificationCompat.Builder(context, CHANNEL_NAME).setContentTitle(pin.getTitle())
+                new NotificationCompat.Builder(context, channel_id)
+                        .setContentTitle(pin.getTitle())
                         .setContentText(pin.getContent())
                         .setSmallIcon(R.drawable.ic_notif_star)
                         .setPriority(pin.getPriority())
@@ -89,6 +141,28 @@ public class NotificationTools {
                                         .putExtra(EXTRA_INTENT, pin), PendingIntent.FLAG_CANCEL_CURRENT | FLAG_IMMUTABLE))
                         .setOngoing(pin.isPersistent());
 
+        if (pin.getVisibility() == Notification.VISIBILITY_PRIVATE && !pin.getContent().isEmpty()) {
+            // If visibility is hidden then an alternative notification can be shown on the lock screen:
+            // More info: https://developer.android.com/develop/ui/views/notifications/build-notification#lockscreenNotification
+            // More info: https://gabrieltanner.org/blog/android-notifications-overview/
+
+            // Show "Contents hidden" placeholder as italic:
+            // https://stackoverflow.com/questions/70698860/how-to-bold-title-in-notification
+            Spannable hiddenContent = styledText(
+                    context.getResources().getText(R.string.message_hidden_private_content),
+                    new StyleSpan(Typeface.ITALIC)
+            );
+
+            NotificationCompat.Builder publicBuilder = new NotificationCompat.Builder(context, channel_id)
+                    .setContentTitle(pin.getTitle())
+                    .setContentText(hiddenContent)
+                    .setContentTitle(pin.getTitle())
+                    .setSmallIcon(R.drawable.ic_notif_star)
+                    .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+
+            builder.setPublicVersion(publicBuilder.build());
+        }
+
         if (pin.isShowActions()) {
             builder.addAction(R.drawable.ic_action_clip,
                     context.getString(R.string.message_save_to_clipboard),
@@ -99,12 +173,7 @@ public class NotificationTools {
 
         if (notificationManager != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-
-                /* Create or update. */
-                NotificationChannel channel = new NotificationChannel(CHANNEL_NAME,
-                        "Pins",
-                        NotificationManager.IMPORTANCE_DEFAULT);
-                notificationManager.createNotificationChannel(channel);
+                createOrUpdateNotificationChannels(context, notificationManager);
             }
 
             Log.i(TAG, "Send notification with pin id " + pin.getIdAsInt() + " to system");

--- a/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/NotificationTools.java
@@ -171,7 +171,7 @@ public class NotificationTools {
         }
     }
 
-    private static Spannable styledText(CharSequence text, StyleSpan style) {
+    private static CharSequence styledText(CharSequence text, StyleSpan style) {
         // https://stackoverflow.com/questions/70698860/how-to-bold-title-in-notification
         Spannable content = new SpannableString(text);
         content.setSpan(style, 0, text.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -207,7 +207,7 @@ public class NotificationTools {
 
             // Show "Contents hidden" placeholder as italic:
             // https://stackoverflow.com/questions/70698860/how-to-bold-title-in-notification
-            Spannable hiddenContent = styledText(
+            CharSequence hiddenContent = styledText(
                     context.getResources().getText(R.string.message_hidden_private_content),
                     new StyleSpan(Typeface.ITALIC)
             );

--- a/app/src/main/java/de/dotwee/micropinner/tools/PreferencesHandler.java
+++ b/app/src/main/java/de/dotwee/micropinner/tools/PreferencesHandler.java
@@ -3,7 +3,7 @@ package de.dotwee.micropinner.tools;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Created by lukas on 18.08.2015 - 16:11

--- a/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
@@ -22,7 +22,7 @@ import android.widget.Spinner;
 import de.dotwee.micropinner.R;
 import de.dotwee.micropinner.presenter.MainPresenter;
 import de.dotwee.micropinner.presenter.MainPresenterImpl;
-import de.dotwee.micropinner.receiver.OnBootReceiver;
+import de.dotwee.micropinner.tools.NotificationTools;
 import de.dotwee.micropinner.view.custom.DialogContentView;
 import de.dotwee.micropinner.view.custom.DialogFooterView;
 import de.dotwee.micropinner.view.custom.DialogHeaderView;
@@ -75,8 +75,8 @@ public class MainDialog extends AppCompatActivity implements MainPresenter.Data 
         // restore previous state
         mainPresenter.restore();
 
-        // simulate device-boot by sending a new intent to class OnBootReceiver
-        sendBroadcast(new Intent(this, OnBootReceiver.class));
+        // If app was closed then restore notifications from previous session:
+        NotificationTools.restoreNotifications(this);
     }
 
     @Override

--- a/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
@@ -6,11 +6,11 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.LayoutRes;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.app.AppCompatDelegate;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
@@ -35,7 +35,7 @@ public class MainDialog extends AppCompatActivity implements MainPresenter.Data 
 
     static {
         AppCompatDelegate.setDefaultNightMode(
-                AppCompatDelegate.MODE_NIGHT_AUTO);
+                AppCompatDelegate.MODE_NIGHT_AUTO_TIME);
     }
 
     /**

--- a/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
@@ -38,7 +38,7 @@ public class MainDialog extends AppCompatActivity implements MainPresenter.Data 
 
     static {
         AppCompatDelegate.setDefaultNightMode(
-                AppCompatDelegate.MODE_NIGHT_AUTO_TIME);
+                AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
     }
 
     private MainPresenter mainPresenter;

--- a/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java
@@ -33,10 +33,15 @@ import de.dotwee.micropinner.view.custom.DialogHeaderView;
 public class MainDialog extends AppCompatActivity implements MainPresenter.Data {
     private static final String TAG = MainDialog.class.getSimpleName();
 
+    /** Used when requesting permission to post notifications. */
+    private static final int PERMISSION_REQUEST_PRESENTER = 0;
+
     static {
         AppCompatDelegate.setDefaultNightMode(
                 AppCompatDelegate.MODE_NIGHT_AUTO_TIME);
     }
+
+    private MainPresenter mainPresenter;
 
     /**
      * This method checks if the user's device is a tablet, depending on the official resource {@link
@@ -56,7 +61,7 @@ public class MainDialog extends AppCompatActivity implements MainPresenter.Data 
 
         this.setContentView(R.layout.dialog_main);
 
-        MainPresenter mainPresenter = new MainPresenterImpl(this, getIntent());
+        mainPresenter = new MainPresenterImpl(this, getIntent(), PERMISSION_REQUEST_PRESENTER);
 
         DialogHeaderView headerView = findViewById(R.id.dialogHeaderView);
         headerView.setMainPresenter(mainPresenter);
@@ -72,6 +77,17 @@ public class MainDialog extends AppCompatActivity implements MainPresenter.Data 
 
         // simulate device-boot by sending a new intent to class OnBootReceiver
         sendBroadcast(new Intent(this, OnBootReceiver.class));
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        if (requestCode == PERMISSION_REQUEST_PRESENTER) {
+            // Request made by main presenter, so let it handle the results:
+            mainPresenter.onRequestPermissionsResult(permissions, grantResults);
+        }
     }
 
     @Override

--- a/app/src/main/java/de/dotwee/micropinner/view/custom/AbstractDialogView.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/custom/AbstractDialogView.java
@@ -1,7 +1,7 @@
 package de.dotwee.micropinner.view.custom;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.widget.FrameLayout;

--- a/app/src/main/java/de/dotwee/micropinner/view/custom/DialogContentView.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/custom/DialogContentView.java
@@ -71,11 +71,8 @@ public class DialogContentView extends AbstractDialogView
     public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
         checkIfPresenterNull();
 
-        switch (compoundButton.getId()) {
-
-            case R.id.checkBoxShowActions:
-                mainPresenter.onShowActions();
-                break;
+        if (compoundButton.getId() == R.id.checkBoxShowActions) {
+            mainPresenter.onShowActions();
         }
     }
 }

--- a/app/src/main/java/de/dotwee/micropinner/view/custom/DialogContentView.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/custom/DialogContentView.java
@@ -41,6 +41,9 @@ public class DialogContentView extends AbstractDialogView
 
         spinnerPriority = findViewById(R.id.spinnerPriority);
         setPriorityAdapter();
+
+        CheckBox showActions = this.findViewById(R.id.checkBoxShowActions);
+        showActions.setOnCheckedChangeListener(this);
     }
 
     private void setVisibilityAdapter() {

--- a/app/src/main/java/de/dotwee/micropinner/view/custom/DialogFooterView.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/custom/DialogFooterView.java
@@ -1,7 +1,7 @@
 package de.dotwee.micropinner.view.custom;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -50,20 +50,15 @@ public class DialogFooterView extends AbstractDialogView implements View.OnClick
     public void onClick(@NonNull View view) {
         checkIfPresenterNull();
 
-        switch (view.getId()) {
-            case R.id.buttonPin:
-                mainPresenter.onButtonPositive();
-                break;
-
-            case R.id.buttonCancel:
-                mainPresenter.onButtonNegative();
-                break;
-
-            default:
-                if (BuildConfig.DEBUG) {
-                    Log.w(TAG, "Registered click on unknown view");
-                }
-                break;
+        int id = view.getId();
+        if (id == R.id.buttonPin) {
+            mainPresenter.onButtonPositive();
+        } else if (id == R.id.buttonCancel) {
+            mainPresenter.onButtonNegative();
+        } else {
+            if (BuildConfig.DEBUG) {
+                Log.w(TAG, "Registered click on unknown view");
+            }
         }
     }
 }

--- a/app/src/main/java/de/dotwee/micropinner/view/custom/DialogHeaderView.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/custom/DialogHeaderView.java
@@ -50,27 +50,19 @@ public class DialogHeaderView extends AbstractDialogView
     @Override
     public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
         checkIfPresenterNull();
-        switch (compoundButton.getId()) {
-
-            case R.id.switchAdvanced:
-                mainPresenter.onViewExpand(isChecked);
-                break;
+        if (compoundButton.getId() == R.id.switchAdvanced) {
+            mainPresenter.onViewExpand(isChecked);
         }
     }
 
     @Override
     public void onClick(View view) {
-        switch (view.getId()) {
-
-            case R.id.linearLayoutHeader:
-                switchAdvanced.performClick();
-                break;
-
-            default:
-                if (BuildConfig.DEBUG) {
-                    Log.w(TAG, "Registered click on unknown view");
-                }
-                break;
+        if (view.getId() == R.id.linearLayoutHeader) {
+            switchAdvanced.performClick();
+        } else {
+            if (BuildConfig.DEBUG) {
+                Log.w(TAG, "Registered click on unknown view");
+            }
         }
     }
 
@@ -84,21 +76,17 @@ public class DialogHeaderView extends AbstractDialogView
     public boolean onLongClick(View view) {
         checkIfPresenterNull();
 
-        switch (view.getId()) {
-
-            case R.id.switchAdvanced:
-                mainPresenter.onSwitchHold();
-                return true;
-
-            case R.id.linearLayoutHeader:
-                mainPresenter.onSwitchHold();
-                return true;
-
-            default:
-                if (BuildConfig.DEBUG) {
-                    Log.w(TAG, "Registered long-click on unknown view");
-                }
-                return false;
+        int id = view.getId();
+        if (id == R.id.switchAdvanced) {
+            mainPresenter.onSwitchHold();
+            return true;
+        } else if (id == R.id.linearLayoutHeader) {
+            mainPresenter.onSwitchHold();
+            return true;
         }
+        if (BuildConfig.DEBUG) {
+            Log.w(TAG, "Registered long-click on unknown view");
+        }
+        return false;
     }
 }

--- a/app/src/main/java/de/dotwee/micropinner/view/custom/DialogHeaderView.java
+++ b/app/src/main/java/de/dotwee/micropinner/view/custom/DialogHeaderView.java
@@ -6,7 +6,8 @@ import android.util.Log;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
-import android.widget.Switch;
+
+import androidx.appcompat.widget.SwitchCompat;
 
 import de.dotwee.micropinner.BuildConfig;
 import de.dotwee.micropinner.R;
@@ -15,10 +16,10 @@ import de.dotwee.micropinner.R;
  * Created by lukas on 25.07.2016.
  */
 public class DialogHeaderView extends AbstractDialogView
-        implements Switch.OnCheckedChangeListener, View.OnClickListener, View.OnLongClickListener {
+        implements SwitchCompat.OnCheckedChangeListener, View.OnClickListener, View.OnLongClickListener {
 
     private static final String TAG = DialogHeaderView.class.getSimpleName();
-    private Switch switchAdvanced;
+    private SwitchCompat switchAdvanced;
 
     public DialogHeaderView(Context context) {
         super(context);

--- a/app/src/main/res/layout/dialog_main.xml
+++ b/app/src/main/res/layout/dialog_main.xml
@@ -9,14 +9,17 @@
 
     <de.dotwee.micropinner.view.custom.DialogHeaderView
         android:id="@+id/dialogHeaderView"
-        style="@style/DialogView" />
+        style="@style/DialogView"
+        android:background="@color/background" />
 
     <de.dotwee.micropinner.view.custom.DialogContentView
         android:id="@+id/dialogContentView"
-        style="@style/DialogView" />
+        style="@style/DialogView"
+        android:layout_weight="1" />
 
     <de.dotwee.micropinner.view.custom.DialogFooterView
         android:id="@+id/dialogFooterView"
-        style="@style/DialogView" />
+        style="@style/DialogView"
+        android:background="@color/background" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_main.xml
+++ b/app/src/main/res/layout/dialog_main.xml
@@ -3,6 +3,8 @@
     style="@style/MainWrapper"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
+    android:layout_margin="16dp"
+    android:background="@color/background"
     tools:context=".view.MainDialog">
 
     <de.dotwee.micropinner.view.custom.DialogHeaderView

--- a/app/src/main/res/layout/dialog_main.xml
+++ b/app/src/main/res/layout/dialog_main.xml
@@ -5,7 +5,8 @@
     android:layout_height="match_parent"
     android:layout_margin="16dp"
     android:background="@color/background"
-    tools:context=".view.MainDialog">
+    tools:context=".view.MainDialog"
+    tools:ignore="Overdraw">
 
     <de.dotwee.micropinner.view.custom.DialogHeaderView
         android:id="@+id/dialogHeaderView"
@@ -15,7 +16,8 @@
     <de.dotwee.micropinner.view.custom.DialogContentView
         android:id="@+id/dialogContentView"
         style="@style/DialogView"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        tools:ignore="InefficientWeight" />
 
     <de.dotwee.micropinner.view.custom.DialogFooterView
         android:id="@+id/dialogFooterView"

--- a/app/src/main/res/layout/dialog_main_content.xml
+++ b/app/src/main/res/layout/dialog_main_content.xml
@@ -32,7 +32,6 @@
                 android:hint="@string/input_hint_content" />
         </TableRow>
 
-
         <TableRow style="@style/DialogView">
 
             <TextView
@@ -50,14 +49,12 @@
 
             <Spinner
                 android:id="@+id/spinnerVisibility"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                style="@style/DialogSpinner"
                 android:layout_column="0" />
 
             <Spinner
                 android:id="@+id/spinnerPriority"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                style="@style/DialogSpinner"
                 android:layout_column="1" />
         </TableRow>
 

--- a/app/src/main/res/layout/dialog_main_content.xml
+++ b/app/src/main/res/layout/dialog_main_content.xml
@@ -6,30 +6,29 @@
 
         <TableRow style="@style/DialogView">
 
-            <TextView
-                style="@style/DialogText.Description"
-                android:layout_column="0"
-                android:text="@string/input_description_title" />
+            <LinearLayout
+                style="@style/DialogView"
+                android:layout_span="2"
+                android:orientation="vertical">
 
-            <TextView
-                style="@style/DialogText.Description"
-                android:layout_column="1"
-                android:text="@string/input_description_content" />
-        </TableRow>
+                <TextView
+                    style="@style/DialogText.Description"
+                    android:text="@string/input_description_title" />
 
-        <TableRow style="@style/DialogView">
+                <EditText
+                    android:id="@+id/editTextTitle"
+                    style="@style/DialogInput.EditText"
+                    android:hint="@string/input_hint_title" />
 
-            <EditText
-                android:id="@+id/editTextTitle"
-                style="@style/DialogInput.EditText"
-                android:layout_column="0"
-                android:hint="@string/input_hint_title" />
+                <TextView
+                    style="@style/DialogText.Description"
+                    android:text="@string/input_description_content" />
 
-            <EditText
-                android:id="@+id/editTextContent"
-                style="@style/DialogInput.EditText"
-                android:layout_column="1"
-                android:hint="@string/input_hint_content" />
+                <EditText
+                    android:id="@+id/editTextContent"
+                    style="@style/DialogInput.EditText"
+                    android:hint="@string/input_hint_content" />
+            </LinearLayout>
         </TableRow>
 
         <TableRow style="@style/DialogView">

--- a/app/src/main/res/layout/dialog_main_content.xml
+++ b/app/src/main/res/layout/dialog_main_content.xml
@@ -1,84 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/DialogContent.Table">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/DialogView">
 
-    <TableRow style="@style/DialogView">
+    <TableLayout style="@style/DialogContent.Table">
 
-        <TextView
-            style="@style/DialogText.Description"
-            android:layout_column="0"
-            android:text="@string/input_description_title" />
+        <TableRow style="@style/DialogView">
 
-        <TextView
-            style="@style/DialogText.Description"
-            android:layout_column="1"
-            android:text="@string/input_description_content" />
-    </TableRow>
+            <TextView
+                style="@style/DialogText.Description"
+                android:layout_column="0"
+                android:text="@string/input_description_title" />
 
-    <TableRow style="@style/DialogView">
+            <TextView
+                style="@style/DialogText.Description"
+                android:layout_column="1"
+                android:text="@string/input_description_content" />
+        </TableRow>
 
-        <EditText
-            android:id="@+id/editTextTitle"
-            style="@style/DialogInput.EditText"
-            android:layout_column="0"
-            android:hint="@string/input_hint_title" />
+        <TableRow style="@style/DialogView">
 
-        <EditText
-            android:id="@+id/editTextContent"
-            style="@style/DialogInput.EditText"
-            android:layout_column="1"
-            android:hint="@string/input_hint_content" />
-    </TableRow>
+            <EditText
+                android:id="@+id/editTextTitle"
+                style="@style/DialogInput.EditText"
+                android:layout_column="0"
+                android:hint="@string/input_hint_title" />
+
+            <EditText
+                android:id="@+id/editTextContent"
+                style="@style/DialogInput.EditText"
+                android:layout_column="1"
+                android:hint="@string/input_hint_content" />
+        </TableRow>
 
 
-    <TableRow style="@style/DialogView">
+        <TableRow style="@style/DialogView">
 
-        <TextView
-            style="@style/DialogText.Description"
-            android:layout_column="0"
-            android:text="@string/input_description_visibility" />
+            <TextView
+                style="@style/DialogText.Description"
+                android:layout_column="0"
+                android:text="@string/input_description_visibility" />
 
-        <TextView
-            style="@style/DialogText.Description"
-            android:layout_column="1"
-            android:text="@string/input_description_priority" />
-    </TableRow>
+            <TextView
+                style="@style/DialogText.Description"
+                android:layout_column="1"
+                android:text="@string/input_description_priority" />
+        </TableRow>
 
-    <TableRow style="@style/DialogView">
+        <TableRow style="@style/DialogView">
 
-        <Spinner
-            android:id="@+id/spinnerVisibility"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_column="0" />
+            <Spinner
+                android:id="@+id/spinnerVisibility"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_column="0" />
 
-        <Spinner
-            android:id="@+id/spinnerPriority"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_column="1" />
-    </TableRow>
+            <Spinner
+                android:id="@+id/spinnerPriority"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_column="1" />
+        </TableRow>
 
-    <TableRow style="@style/DialogView">
+        <TableRow style="@style/DialogView">
 
-        <CheckBox
-            android:id="@+id/checkBoxPersistentPin"
-            style="@style/DialogText.CheckBox"
-            android:layout_marginTop="16dp"
-            android:layout_span="2"
-            android:text="@string/input_description_makepinpersistent" />
+            <CheckBox
+                android:id="@+id/checkBoxPersistentPin"
+                style="@style/DialogText.CheckBox"
+                android:layout_marginTop="16dp"
+                android:layout_span="2"
+                android:text="@string/input_description_makepinpersistent" />
 
-    </TableRow>
+        </TableRow>
 
-    <TableRow style="@style/DialogView">
+        <TableRow style="@style/DialogView">
 
-        <CheckBox
-            android:id="@+id/checkBoxShowActions"
-            style="@style/DialogText.CheckBox"
-            android:layout_marginTop="4dp"
-            android:layout_span="2"
-            android:text="@string/input_description_shownotificationactions" />
+            <CheckBox
+                android:id="@+id/checkBoxShowActions"
+                style="@style/DialogText.CheckBox"
+                android:layout_marginTop="4dp"
+                android:layout_span="2"
+                android:text="@string/input_description_shownotificationactions" />
 
-    </TableRow>
+        </TableRow>
 
-</TableLayout>
+    </TableLayout>
+</ScrollView>

--- a/app/src/main/res/layout/dialog_main_content.xml
+++ b/app/src/main/res/layout/dialog_main_content.xml
@@ -18,7 +18,8 @@
                 <EditText
                     android:id="@+id/editTextTitle"
                     style="@style/DialogInput.EditText"
-                    android:hint="@string/input_hint_title" />
+                    android:hint="@string/input_hint_title"
+                    android:importantForAutofill="no" />
 
                 <TextView
                     style="@style/DialogText.Description"
@@ -27,7 +28,8 @@
                 <EditText
                     android:id="@+id/editTextContent"
                     style="@style/DialogInput.EditText"
-                    android:hint="@string/input_hint_content" />
+                    android:hint="@string/input_hint_content"
+                    android:importantForAutofill="no" />
             </LinearLayout>
         </TableRow>
 

--- a/app/src/main/res/layout/dialog_main_head.xml
+++ b/app/src/main/res/layout/dialog_main_head.xml
@@ -25,7 +25,7 @@
         android:layout_height="wrap_content"
         android:background="@android:color/transparent">
 
-        <Switch
+        <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/switchAdvanced"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,6 @@
     <color name="primary">#673AB7</color>
     <color name="primary_dark">#512DA8</color>
     <color name="activityBackground">#00FFFFFF</color>
+    <color name="accent">#FF5252</color>
+    <color name="background">#FAFAFA</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="primary">#673AB7</color>
     <color name="primary_dark">#512DA8</color>
+    <color name="activityBackground">#00FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <dimen name="dialog_content_padding_24">24dp</dimen>
-    <dimen name="dialog_content_padding_20">24dp</dimen>
-    <dimen name="dialog_content_padding_16">24dp</dimen>
+    <dimen name="dialog_content_padding_20">20dp</dimen>
+    <dimen name="dialog_content_padding_16">16dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="input_hint_content">Content</string>
 
     <string name="message_visibility_unsupported">Hey! Seems like you are using a older Android Version, where the visibility-setting is unsupported.</string>
+    <string name="message_notifications_permission_denied">Permission to send notifications is required for this app to function.</string>
     <string name="message_clipped_pin">Pin has been copied to clipboard.</string>
     <string name="message_empty_title">The title has to contain text.</string>
     <string name="message_save_to_clipboard">Save to clipboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,11 @@
     <string name="message_clipped_pin">Pin has been copied to clipboard.</string>
     <string name="message_empty_title">The title has to contain text.</string>
     <string name="message_save_to_clipboard">Save to clipboard</string>
+    <string name="message_hidden_private_content">Contents hidden</string>
+
+    <string name="notifications_channel_public">Public Pins</string>
+    <string name="notifications_channel_private">Private Pins</string>
+    <string name="notifications_channel_secret">Secret Pins</string>
 
     <string name="visibility_public">public</string>
     <string name="visibility_private">private</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">MicroPinner</string>
 
     <string name="main_name">New Pin</string>
@@ -22,15 +22,15 @@
     <string name="input_hint_content">Content</string>
 
     <string name="message_visibility_unsupported">Hey! Seems like you are using a older Android Version, where the visibility-setting is unsupported.</string>
-    <string name="message_notifications_permission_denied">Permission to send notifications is required for this app to function.</string>
+    <string name="message_notifications_permission_denied" tools:ignore="MissingTranslation">Permission to send notifications is required for this app to function.</string>
     <string name="message_clipped_pin">Pin has been copied to clipboard.</string>
     <string name="message_empty_title">The title has to contain text.</string>
     <string name="message_save_to_clipboard">Save to clipboard</string>
-    <string name="message_hidden_private_content">Contents hidden</string>
+    <string name="message_hidden_private_content" tools:ignore="MissingTranslation">Contents hidden</string>
 
-    <string name="notifications_channel_public">Public Pins</string>
-    <string name="notifications_channel_private">Private Pins</string>
-    <string name="notifications_channel_secret">Secret Pins</string>
+    <string name="notifications_channel_public" tools:ignore="MissingTranslation">Public Pins</string>
+    <string name="notifications_channel_private" tools:ignore="MissingTranslation">Private Pins</string>
+    <string name="notifications_channel_secret" tools:ignore="MissingTranslation">Secret Pins</string>
 
     <string name="visibility_public">public</string>
     <string name="visibility_private">private</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,9 +44,16 @@
         <item name="android:layout_marginLeft">4dp</item>
         <item name="android:layout_marginRight">4dp</item>
 
+        <!--
+        <item name="android:maxLines">5</item>
+        -->
+
+        <item name="android:scrollHorizontally">false</item>
+        <item name="android:scrollbars">vertical</item>
+
         <item name="android:maxWidth">128dp</item>
         <item name="android:inputType">
-            textCapSentences|textAutoComplete|textImeMultiLine|textAutoCorrect|text|textMultiLine
+            textCapSentences|textAutoCorrect|text|textMultiLine|textImeMultiLine
         </item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,7 +4,9 @@
         <item name="colorAccent">@color/accent</item>
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryDark">@color/primary_dark</item>
-        <item name="android:background">@color/background</item>
+
+        <item name="android:windowBackground">@color/activityBackground</item>
+        <item name="android:windowIsTranslucent">true</item>
 
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="DialogTheme" parent="Theme.AppCompat.DayNight.Dialog">
         <item name="colorAccent">@color/accent</item>
@@ -83,7 +83,15 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">wrap_content</item>
         <item name="android:textColor">?attr/colorAccent</item>
-        <item name="android:layout_margin">8dp</item>
+        <item name="android:layout_margin">4dp</item>
+    </style>
+
+    <style name="DialogSpinner" parent="Widget.AppCompat.Spinner">
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:spinnerMode">dropdown</item>
+        <item name="android:overlapAnchor" tools:ignore="NewApi">false</item>
+        <item name="android:padding">8dp</item>
     </style>
 
     <style name="DialogFooter">

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -12,7 +12,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 04 18:51:18 CEST 2018
+#Sat Dec 24 18:42:03 CET 2022
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
Previously I was using another app ([Notification Memo](https://play.google.com/store/apps/details?id=dk.nicolai.buch.andersen.memo&pli=1)) but it got a lot buggier in Android 13 so I searched for alternatives and found this app on F-Droid as well as another app called [p!n](https://f-droid.org/en/packages/de.nproth.pin/). Of the apps I found I prefer most things in this app but it had some bugs and therefore I made some changes in order to fix those.

- Updated app to work with latest Android Studio
  - Bumped compileSdk and targetSdk
  - Updated dependencies
  - Migrated to `androidx` from `android.support`.
    - [Class Mappings  |  Android Developers](https://developer.android.com/jetpack/androidx/migrate/class-mappings) was helpful.
  - Updated som tests that failed, mostly ParentPin tests that timed out on newer android versions.
  - Manually request permission to send notifications, required in Android 13 (sdk 33).
- Allow more actions when multi-selecting text, such as searching the text online. (From [AndroidManifest.xml in p!n](https://github.com/nproth/pin/blob/aa0a701445107590a2b9dc116330a213c6171983/app/src/main/AndroidManifest.xml#L8-L14))
- Follow the system's night mode setting.
- Fix styling of window background so that selecting text doesn't cause "popups", issue #20. (From [styles.xml in p!n](https://github.com/nproth/pin/blob/aa0a701445107590a2b9dc116330a213c6171983/app/src/main/res/values/styles.xml#L10-L11))
- It seems that a change listener for the "show notifications action" checkbox was never registered, even though most of the code was written. So I registered that listener which should fix #18.
- Make the content view scrollable if it gets too large, should fix #19. 
  - You previously made [a comment](https://github.com/dotWee/MicroPinner/pull/16#issuecomment-341730441) against this in PR #16. Not quite sure if that was only about the case where the dialog was always too large or if it was about the case where the dialog grew too large. Anyway I think a scrollable dialog should be fine [according to the guidelines](https://m3.material.io/components/dialogs/guidelines#de17dbd2-7ecf-459e-af95-0f7132a55e40) as long as the header and footer remain fixed (which they are in my implementation). Even if you disagree it should still be better than just breaking the app which is what happened before.
- I created one notifications channel (category) per visibility level. This should make it easier to configure Android to actually hide the content from the lock screen (at least this is the case on my Samsung phone).
  - I also added a "public version" of the private notification as specified [here](https://developer.android.com/develop/ui/views/notifications/build-notification#lockscreenNotification). (I also used info from [this blog post](https://gabrieltanner.org/blog/android-notifications-overview/)).
    - This allows the notification's title to still be shown on the lock screen while the content is hidden.
- I changed the styling of the spinners so that their drop down's don't overlap with the widget itself. This makes it easier to use the gesture where you drag down on the spinner and then lift your finger at the option you want to select.
- Finally I placed the text inputs vertically. I made this change last so that if you don't like it then its easy to skip.
  - This makes sense because the title is usually not multi line while the content definitively can be. If that happens and the inputs are in different columns (as they were previously) then most of the space in the dialog isn't used which isn't very efficient.

Edit:
I did some additional changes as I found more things to fix:
- Set `android:noHistory` to `true` in order for the app to close when you back out of it. If this isn't done then tapping a notification to edit it after one previously backed out of creating a new pin causes weird behavior. Specifically the app is reopened with the unfinished new pin.
- Changed the name of the app icon to "MicroPinner" from "New Pin". Should fix #29.
- Notifications were only restored after reboots despite the fact that the reboot receiver was invoked from the main activity at [line 74 of `MainDialog.java`](https://github.com/dotWee/MicroPinner/blob/3095ece11dc1ad5bd74a499430d640825e19b322/app/src/main/java/de/dotwee/micropinner/view/MainDialog.java#L74). This is because it failed the first check in the reboot receiver at [line 21 of `OnBootReceiver.java`](https://github.com/dotWee/MicroPinner/blob/3095ece11dc1ad5bd74a499430d640825e19b322/app/src/main/java/de/dotwee/micropinner/receiver/OnBootReceiver.java#L21-L25). I removed that check and added a different check so that the restore code only runs once after the app is started. Force stopping the app or restarting the phone should still cause the notifications to be restored. This fixes #23.